### PR TITLE
Терминология: функциональный/классовый компонент

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -53,13 +53,14 @@
 | bundler | бандлер |
 | callback | колбэк |
 | camelCase | *camelCase* |
+| class component | классовый компонент |
 | (un)controlled component | (не)контролируемый компонент |
 | debugging | отладка |
 | DOM container | DOM-контейнер |
 | error | ошибка |
 | debugging | отладка |
 | framework | фреймворк |
-| functional component | функциональный компонент |
+| function component | функциональный компонент |
 | hook | хук |
 | key | ключ |
 | lazy initialization | ленивая инициализация |


### PR DESCRIPTION
На английском мы отошли от "functional" в сторону "function component". То есть компонент-класс и компонент-функция. Но это как-то совсем странно по-русски.

Думаю ок будет оставить функциональный/классовый компонент. Кажется относительно популярно так уже.

В будущем это будет не так релевантно по мере того как классы уходят на второй план.