### PR TITLE
Терминология: внутреннее состояние

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -65,6 +65,7 @@
 | lazy initialization | ленивая инициализация |
 | library | библиотека |
 | lifting state up | подъём состояния, поднимать состояние |
+| local state | внутреннее состояние |
 | lowercase | нижний регистр |
 | mock | фиктивный |
 | (im)mutable | (им)мутабельный |


### PR DESCRIPTION
Можно конечно «локальное», но мне кажется русское слово «внутреннее» имеет тот же смысл, и даже в контексте реакта встречается чаще.