### PR TITLE
Терминология: задержка, предохранитель

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -71,6 +71,7 @@
 | debugging | отладка |
 | development | разработка |
 | development mode | режим разработки |
+| error boundary | предохранитель |
 | framework | фреймворк |
 | function component | функциональный компонент |
 | hook | хук |
@@ -111,6 +112,7 @@
 | state | состояние |
 | stateful component | компонент с состоянием |
 | stateless component | компонент без состояния |
+| suspense | задержка |
 | tag | тег |
 | template literals | шаблонные строки |
 | tutorial | введение |


### PR DESCRIPTION
Error boundaries слишком новые, я особо в русском вариантов не видел. Мне кажется, предохранитель очень четкая метафора, и это лучше «границ ошибки».

Suspense пока на русском вообще нет (слишком новая фича), мне кажется есть шанс назвать это «задержкой».