### PR TITLE
Терминология: инструменты разработки

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -67,6 +67,7 @@
 | (un)controlled component | (не)контролируемый компонент |
 | custom hooks | пользовательские хуки |
 | debugging | отладка |
+| developer tools | инструменты разработки |
 | DOM container | DOM-контейнер |
 | error | ошибка |
 | effect | эффект |


### PR DESCRIPTION
Хочу убрать гендер, так что «разработки», а не «разработчика».