### PR TITLE
Fix title in refs-must-have-owner.md

### DIFF
--- a/content/warnings/refs-must-have-owner.md
+++ b/content/warnings/refs-must-have-owner.md
@@ -1,5 +1,5 @@
 ---
-title: Предупреждение: У рефа должен быть владелец
+title: "Предупреждение: У рефа должен быть владелец"
 layout: single
 permalink: warnings/refs-must-have-owner.html
 ---


### PR DESCRIPTION
Добавил кавычки в `title` в файле `content/warnings/refs-must-have-owner.md`.

Иначе gatsby при сборке писал ошибку
```
error Error processing Markdown file /home/tesler/git/ru.reactjs.org/content/warnings/refs-must-have-owner.md:

      incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 2, column 22:
    title: Предупреждение: У рефа должен быть владелец
                         ^
```
и страница не отображалась.
