### PR TITLE
Fix reference-events.md

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -66,7 +66,7 @@ function onClick(event) {
 
 ## Поддерживаемые события {#supported-events}
 
-React нормализует события так, чтобы они содержали одинаковые свойства во всех бразурах.
+React нормализует события так, чтобы они содержали одинаковые свойства во всех браузерах.
 
 Обработчики ниже вызываются на фазе всплытия (bubbling). А чтобы зарегистрировать событие на фазе перехвата (capture), просто добавьте `Capture` к имени события; например, вместо использования `onClick` используйте `onClickCapture`, чтобы обработать событие на фазе перехвата.
 
@@ -293,7 +293,7 @@ DOMTouchList touches
 onScroll
 ```
 
-Properties:
+Свойства:
 
 ```javascript
 number detail
@@ -302,9 +302,9 @@ DOMAbstractView view
 
 * * *
 
-### Событий колеса мыши {#wheel-events}
+### События колеса мыши {#wheel-events}
 
-Event names:
+Названия событий:
 
 ```
 onWheel
@@ -321,7 +321,7 @@ number deltaZ
 
 * * *
 
-### Media Events {#media-events}
+### События в медиа объектах {#media-events}
 
 Названия событий:
 
@@ -344,7 +344,7 @@ onLoad onError
 
 * * *
 
-### События анимацй {#animation-events}
+### События анимаций {#animation-events}
 
 Названия событий:
 


### PR DESCRIPTION
Для "Media Events" использовал перевод из [MDN](https://developer.mozilla.org/ru/docs/Web/Guide/Events/Media_events).

<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
