### PR TITLE
Fix missed typos in reference-events

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -218,7 +218,7 @@ boolean shiftKey
 
 ### События курсора {#pointer-events}
 
-Название собыий:
+Названия событий:
 
 ```
 onPointerDown onPointerMove onPointerUp onPointerCancel onGotPointerCapture


### PR DESCRIPTION
<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
