### PR TITLE
Fix typos, missed translations in render-props

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -20,7 +20,7 @@ permalink: docs/render-props.html
 
 ## Использование рендер-пропа для сквозных задач {#use-render-props-for-cross-cutting-concerns}
 
-Компоненты это основа повторного использования кода в React. Однако бывает неочевидно, как сделать, чтобы одни компоненты разделяли своё инкапсулированное состояние или поведение с другими компонентами, заинтересованными в таком же состоянии или поведении.
+Компоненты -- это основа повторного использования кода в React. Однако бывает неочевидно, как сделать, чтобы одни компоненты разделяли своё инкапсулированное состояние или поведение с другими компонентами, заинтересованными в таком же состоянии или поведении.
 
 Например, следующий компонент отслеживает положение мыши в приложении:
 
@@ -42,8 +42,8 @@ class MouseTracker extends React.Component {
   render() {
     return (
       <div style={{ height: '100%' }} onMouseMove={this.handleMouseMove}>
-        <h1>Move the mouse around!</h1>
-        <p>The current mouse position is ({this.state.x}, {this.state.y})</p>
+        <h1>Перемещайте курсор мыши!</h1>
+        <p>Текущее положение курсора мыши: ({this.state.x}, {this.state.y})</p>
       </div>
     );
   }
@@ -77,7 +77,7 @@ class Mouse extends React.Component {
       <div style={{ height: '100%' }} onMouseMove={this.handleMouseMove}>
 
         {/* ...но как можно отрендерить что-то, кроме <p>? */}
-        <p>The current mouse position is ({this.state.x}, {this.state.y})</p>
+        <p>Текущее положение курсора мыши: ({this.state.x}, {this.state.y})</p>
       </div>
     );
   }
@@ -87,7 +87,7 @@ class MouseTracker extends React.Component {
   render() {
     return (
       <div>
-        <h1>Move the mouse around!</h1>
+        <h1>Перемещайте курсор мыши!</h1>
         <Mouse />
       </div>
     );
@@ -145,7 +145,7 @@ class MouseTracker extends React.Component {
   render() {
     return (
       <div>
-        <h1>Move the mouse around!</h1>
+        <h1>Перемещайте курсор мыши!</h1>
         <MouseWithCat />
       </div>
     );
@@ -199,7 +199,7 @@ class MouseTracker extends React.Component {
   render() {
     return (
       <div>
-        <h1>Move the mouse around!</h1>
+        <h1>Перемещайте курсор мыши!</h1>
         <Mouse render={mouse => (
           <Cat mouse={mouse} />
         )}/>
@@ -239,11 +239,11 @@ function withMouse(Component) {
 
 Важно запомнить, что из названия паттерна «рендер-проп» вовсе не следует, что для его использования *вы должны обязательно называть проп `render`*. На самом деле, [*любой* проп, который используется компонентом и является функцией рендеринга, технически является и «рендер-пропом»](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce).
 
-Несмотря на то, что в вышеприведенных примерах мы используем `render`, мы можем также легко использовать проп `children`!
+Несмотря на то, что в вышеприведённых примерах мы используем `render`, мы можем также легко использовать проп `children`!
 
 ```js
 <Mouse children={mouse => (
-  <p>The mouse position is {mouse.x}, {mouse.y}</p>
+  <p>Текущее положение курсора мыши: {mouse.x}, {mouse.y}</p>
 )}/>
 ```
 
@@ -252,7 +252,7 @@ function withMouse(Component) {
 ```js
 <Mouse>
   {mouse => (
-    <p>The mouse position is {mouse.x}, {mouse.y}</p>
+    <p>Текущее положение курсора мыши: {mouse.x}, {mouse.y}</p>
   )}
 </Mouse>
 ```
@@ -272,7 +272,7 @@ Mouse.propTypes = {
 
 ### Будьте осторожны при использовании рендер-проп вместе с React.PureComponent {#be-careful-when-using-render-props-with-reactpurecomponent}
 
-Использование рендер-пропа может свести на нет преимущество, которое дает [`React.PureComponent`](/docs/react-api.html#reactpurecomponent), если вы создаете функцию внутри метода `render`. Это связано с тем, что поверхностное сравнение пропсов всегда будет возвращать `false` для новых пропсов и каждый `render` будет генерировать новое значение для рендер-пропа.
+Использование рендер-пропа может свести на нет преимущество, которое даёт [`React.PureComponent`](/docs/react-api.html#reactpurecomponent), если вы создаете функцию внутри метода `render`. Это связано с тем, что поверхностное сравнение пропсов всегда будет возвращать `false` для новых пропсов и каждый `render` будет генерировать новое значение для рендер-пропа.
 
 Например, в продолжение нашего `<Mouse>` компонента упомянутого выше, если `Mouse` наследуется от `React.PureComponent` вместо `React.Component`, наш пример будет выглядеть следующим образом:
 
@@ -285,7 +285,7 @@ class MouseTracker extends React.Component {
   render() {
     return (
       <div>
-        <h1>Move the mouse around!</h1>
+        <h1>Перемещайте курсор мыши!</h1>
 
         {/*
           Это плохо! Значение рендер-пропа будет
@@ -315,7 +315,7 @@ class MouseTracker extends React.Component {
   render() {
     return (
       <div>
-        <h1>Move the mouse around!</h1>
+        <h1>Перемещайте курсор мыши!</h1>
         <Mouse render={this.renderTheCat} />
       </div>
     );


### PR DESCRIPTION
<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
