### PR TITLE
Header: translate link to Languages page

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -214,7 +214,7 @@ const Header = ({location}: {location: Location}) => (
                   display: 'none',
                 },
               }}>
-              Languages
+              Переводы
             </span>
           </Link>
           <a


### PR DESCRIPTION
Несмотря на то, что просится перевод "Языки", я хочу предложить вариант "Переводы". Не знаю как в англ, но русском это лучше понимается...

Например, так сделано в [русском переводе Vue.js](https://ru.vuejs.org/v2/guide/index.html), но там и в оригинале не _Languages_, а _Translations_. Но, возможно, есть какая-то тонкая разница между этим, поэтому открываю PR.