### PR TITLE
Корректная работа типографа

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -88,6 +88,7 @@ module.exports = {
           },
           'gatsby-remark-copy-linked-files',
           'gatsby-remark-smartypants',
+          'gatsby-remark-typography', // only for Russian translation
         ],
       },
     },
@@ -160,6 +161,5 @@ module.exports = {
     },
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-catch-links',
-    'gatsby-remark-typography', // only for Russian translation
   ],
 };

--- a/plugins/gatsby-remark-typography/gatsby-node.js
+++ b/plugins/gatsby-remark-typography/gatsby-node.js
@@ -4,20 +4,11 @@ const Typograf = require('typograf');
 
 exports.onPreExtractQueries = async ({store, getNodes}) => {
   const tp = new Typograf({locale: ['ru']});
-  const fields = ['title', 'content'];
   const markdownNodes = getNodes().filter(node => {
     return node.internal.type === 'MarkdownRemark';
   });
 
   markdownNodes.forEach(node => {
-    fields.forEach(field => {
-      const value = node.frontmatter[field];
-
-      if (!value) {
-        return;
-      }
-
-      node.frontmatter[field] = tp.execute(value);
-    });
+    node.frontmatter.title = tp.execute(node.frontmatter.title)
   });
 };

--- a/plugins/gatsby-remark-typography/gatsby-node.js
+++ b/plugins/gatsby-remark-typography/gatsby-node.js
@@ -9,6 +9,6 @@ exports.onPreExtractQueries = async ({store, getNodes}) => {
   });
 
   markdownNodes.forEach(node => {
-    node.frontmatter.title = tp.execute(node.frontmatter.title)
+    node.frontmatter.title = tp.execute(node.frontmatter.title);
   });
 };

--- a/plugins/gatsby-remark-typography/index.js
+++ b/plugins/gatsby-remark-typography/index.js
@@ -1,19 +1,19 @@
 'use strict';
 
-const visit = require(`unist-util-visit`)
+const visit = require(`unist-util-visit`);
 const Typograf = require('typograf');
 
-module.exports = ({ markdownAST }, pluginOptions = {}) => {
+module.exports = ({markdownAST}, pluginOptions = {}) => {
   visit(markdownAST, `text`, node => {
     const tp = new Typograf({locale: ['ru']});
     const disabledRules = ['common/space/trimRight', 'common/space/trimLeft'];
-    
+
     disabledRules.forEach(rule => {
-        tp.disableRule(rule);
+      tp.disableRule(rule);
     });
-    
+
     node.value = String(tp.execute(node.value));
-  })
+  });
 
   return markdownAST;
-}
+};

--- a/plugins/gatsby-remark-typography/index.js
+++ b/plugins/gatsby-remark-typography/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const visit = require(`unist-util-visit`)
+const Typograf = require('typograf');
+
+module.exports = ({ markdownAST }, pluginOptions = {}) => {
+  visit(markdownAST, `text`, node => {
+    const tp = new Typograf({locale: ['ru']});
+    const disabledRules = ['common/space/trimRight', 'common/space/trimLeft'];
+    
+    disabledRules.forEach(rule => {
+        tp.disableRule(rule);
+    });
+    
+    node.value = String(tp.execute(node.value));
+  })
+
+  return markdownAST;
+}


### PR DESCRIPTION
Короче немного ошибся с тем, как должен работать типограф :man_facepalming: 

В общем, файл `gatsby-node.js` - типографирует заголовки, `index.js` - текстовые узлы Markdown-дерева (с отключением удалением пробелов справа и слева, нужно чтобы корректно отображался конечный HTML).
Всё, теперь работает, как и должен.