### PR TITLE
Fixing header, search bar no more overlaps link

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -55,7 +55,7 @@ const Header = ({location}: {location: Location}) => (
             },
 
             [media.greaterThan('small')]: {
-              width: 'calc(100% / 6)',
+              width: '100px',
             },
             [media.lessThan('small')]: {
               flex: '0 0 auto',
@@ -138,11 +138,6 @@ const Header = ({location}: {location: Location}) => (
           <HeaderLink
             isActive={location.pathname.includes('/community/')}
             title="Сообщество"
-            to="/community/support.html"
-          />
-          <HeaderLink
-            isActive={location.pathname.includes('/community/')}
-            title="Community"
             to="/community/support.html"
           />
         </nav>


### PR DESCRIPTION
Current:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/12317269/53769023-b5369280-3eeb-11e9-8e1f-a613e7510cb7.png">

With PR:
<img width="715" alt="image" src="https://user-images.githubusercontent.com/12317269/53769156-1b231a00-3eec-11e9-85ea-8e51e2761615.png">

En original:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/12317269/53769113-f9c22e00-3eeb-11e9-849e-5da133803a95.png">

