### PR TITLE
Fix displaying W3C

### DIFF
--- a/plugins/gatsby-remark-typography/index.js
+++ b/plugins/gatsby-remark-typography/index.js
@@ -6,7 +6,7 @@ const Typograf = require('typograf');
 module.exports = ({markdownAST}, pluginOptions = {}) => {
   visit(markdownAST, 'text', node => {
     const tp = new Typograf({locale: ['ru']});
-    const disabledRules = ['common/space/trimRight', 'common/space/trimLeft'];
+    const disabledRules = ['common/space/trimRight', 'common/space/trimLeft', 'common/symbols/cf'];
 
     disabledRules.forEach(rule => {
       tp.disableRule(rule);


### PR DESCRIPTION
Плагин `gatsby-remark-typography` трансформирует `W3C` в `W3 °C`.
Из-за правила [common/symbols/cf](https://github.com/typograf/typograf/blob/dev/src/rules/common/symbols/cf.js) для [Типографа](https://github.com/typograf/typograf)

Например страница [Обработка событий](https://ru.reactjs.org/docs/handling-events.html) (Ссылка `спецификацией W3 °C`)
[Исправленная страница](https://deploy-preview-299--ru-reactjs.netlify.com/docs/handling-events.html)

![До](https://user-images.githubusercontent.com/8356421/55710811-17574b80-59f4-11e9-8c5a-b49b673f6100.png)
![После](https://user-images.githubusercontent.com/8356421/55710810-17574b80-59f4-11e9-9e29-98f208654eb7.png)