### PR TITLE
Update conferencesand reference-react-dom

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -57,11 +57,6 @@ August 22-23, 2019. Salt Lake City, USA.
 
 [Website](https://www.reactrally.com/) - [Twitter](https://twitter.com/ReactRally) - [Instagram](https://www.instagram.com/reactrally/)
 
-### React Rally 2019
-August 22-23, 2019. Salt Lake City, USA.
-
-[Website](https://www.reactrally.com/) - [Twitter](https://twitter.com/ReactRally) - [Instagram](https://www.instagram.com/reactrally/)
-
 ### ComponentsConf 2019 {#componentsconf-2019}
 September 6, 2019 in Melbourne, Australia
 

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -30,7 +30,7 @@ React поддерживает все популярные браузеры, в�
 
 ## Справочник {#browser-support}
 
-### `render()`
+### `render()` {#render}
 
 ```javascript
 ReactDOM.render(element, container[, callback])


### PR DESCRIPTION
Обновлён `conferences.md`. Удален дубликат конференции "React Rally".
Обновлён `reference-react-dom.md`. Добавил пропущенный якорь.
