### PR TITLE
fix(DOM section): height -> rect.height

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -491,7 +491,7 @@ function MeasureExample() {
     <>
       <h1 ref={ref}>Привет, мир</h1>
       {rect !== null &&
-      <h2>Заголовок выше имеет высоту {Math.round(height)} пикселей</h2>
+      <h2>Заголовок выше имеет высоту {Math.round(rect.height)} пикселей</h2>
       }
     </>
   );


### PR DESCRIPTION
`height` is not defined in this example, should be `rect.height`

`rect` is DOMRect element so we can grab `width` or `height` from it.

**Если ваш пулреквест является исправлением бага, а не переводом, то сперва убедитесь, что проблема относится ТОЛЬКО к https://ru.reactjs.org, а не к https://reactjs.org.** Если это не так, то пулреквест следует открыть в родительском репозитории.

<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
