### PR TITLE
Fix blockquote

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -191,7 +191,6 @@ const value = useContext(MyContext);
 
 >Совет
 >
-
 >Если вы были знакомы с API контекстов до появления хуков, то вызов `useContext(MyContext)` аналогичен выражению `static contextType = MyContext` в классе, либо компоненту `<MyContext.Provider>`.
 >
 >`useContext (MyContext)` позволяет только *читать* контекст и подписываться на его изменения. Вам всё ещё нужен `<MyContext.Provider>` выше в дереве, чтобы *предоставить* значение для этого контекста.


### PR DESCRIPTION
Исправлен блок совета: убрана лишняя пустая строка, которая разбивала его на две части.