### PR TITLE
translate TestRenderer.act()

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -111,11 +111,11 @@ TestRenderer.create(element, options);
 TestRenderer.act(callback);
 ```
 
-Подобно [помощнику `act()` из `react-dom/test-utils`](/docs/test-utils.html#act), `TestRenderer.act` подготавливает компонент для проверки утверждений. Используйте эту версию `act()` для оборачивания `TestRenderer.create` и `testRenderer.update`.
+Подобно [вспомогательному методу `act()` из `react-dom/test-utils`](/docs/test-utils.html#act), `TestRenderer.act` подготавливает компонент для проверки утверждений. Используйте эту версию `act()` для оборачивания `TestRenderer.create` и `testRenderer.update`.
 
 ```javascript
 import {create, act} from 'react-test-renderer';
-import App from './app.js'; // The component being tested
+import App from './app.js'; // Тестируемый компонент
 
 // рендер компонента
 let root; 

--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -111,27 +111,27 @@ TestRenderer.create(element, options);
 TestRenderer.act(callback);
 ```
 
-Similar to the [`act()` helper from `react-dom/test-utils`](/docs/test-utils.html#act), `TestRenderer.act` prepares a component for assertions. Use this version of `act()` to wrap calls to `TestRenderer.create` and `testRenderer.update`.
+Подобно [помощнику `act()` из `react-dom/test-utils`](/docs/test-utils.html#act), `TestRenderer.act` подготавливает компонент для проверки утверждений. Используйте эту версию `act()` для оборачивания `TestRenderer.create` и `testRenderer.update`.
 
 ```javascript
 import {create, act} from 'react-test-renderer';
 import App from './app.js'; // The component being tested
 
-// render the component
+// рендер компонента
 let root; 
 act(() => {
   root = create(<App value={1}/>)
 });
 
-// make assertions on root 
+// проверка утверждений
 expect(root.toJSON()).toMatchSnapshot();
 
-// update with some different props
+// обновление с некоторыми отличающимися пропсами
 act(() => {
   root = root.update(<App value={2}/>);
 })
 
-// make assertions on root 
+// проверка утвеждений 
 expect(root.toJSON()).toMatchSnapshot();
 ```
 


### PR DESCRIPTION
**Если ваш пулреквест является исправлением бага, а не переводом, то сперва убедитесь, что проблема относится ТОЛЬКО к https://ru.reactjs.org, а не к https://reactjs.org.** Если это не так, то пулреквест следует открыть в родительском репозитории.

<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
