### PR TITLE
Fix variables name inconsistency in jumpTo()

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1008,7 +1008,7 @@ const doubled = numbers.map(x => x * 2); // [2, 4, 6]
 
 Используя метод `map`, мы можем отобразить историю наших ходов в React-элементы, представленные кнопками на экране, и отрисовать список кнопок для «перехода» к прошлым ходам.
 
-Давайте применим `map` к `history` внутри метода `render` Game-компонента:
+Давайте применим `map` к `history` внутри метода `render` Game-компонента (мы не будем использовать первый аргумент, поэтому обозначим его `_`):
 
 ```javascript{6-15,34}
   render() {
@@ -1016,13 +1016,13 @@ const doubled = numbers.map(x => x * 2); // [2, 4, 6]
     const current = history[history.length - 1];
     const winner = calculateWinner(current.squares);
 
-    const moves = history.map((step, move) => {
-      const desc = move ?
-        'Перейти к ходу #' + move :
+    const moves = history.map((_, step) => {
+      const desc = step ?
+        'Перейти к ходу #' + step :
         'К началу игры';
       return (
         <li>
-          <button onClick={() => this.jumpTo(move)}>{desc}</button>
+          <button onClick={() => this.jumpTo(step)}>{desc}</button>
         </li>
       );
     });
@@ -1105,16 +1105,16 @@ const doubled = numbers.map(x => x * 2); // [2, 4, 6]
 
 В истории игры крестики-нолики каждый прошлый ход имеет уникальный идентификатор: это номер хода в последовательности. Ходы никогда не меняют свой порядок, не удаляются и не добавляются в середину последовательности, так что вполне безопасно пользоваться индексом в качестве ключа.
 
-В методе `render` компонента Game мы можем добавить ключ следующим образом `<li key={move}>` и предупреждения от React об отсутствующих ключах должны пропасть:
+В методе `render` компонента Game мы можем добавить ключ следующим образом `<li key={step}>` и предупреждения от React об отсутствующих ключах должны пропасть:
 
 ```js{6}
-    const moves = history.map((step, move) => {
-      const desc = move ?
-        'Перейти к ходу #' + move :
+    const moves = history.map((_, step) => {
+      const desc = step ?
+        'Перейти к ходу #' + step :
         'К началу игры';
       return (
-        <li key={move}>
-          <button onClick={() => this.jumpTo(move)}>{desc}</button>
+        <li key={step}>
+          <button onClick={() => this.jumpTo(step)}>{desc}</button>
         </li>
       );
     });


### PR DESCRIPTION
I think it will be better to understand if we change `const moves = history.map((step, move) => {...})` to `const moves = history.map((_,step) => {...})` because we don't use `step` variable in map method, but later we use `jumpTo(step)` and it's confusing.

**Если ваш пулреквест является исправлением бага, а не переводом, то сперва убедитесь, что проблема относится ТОЛЬКО к https://ru.reactjs.org, а не к https://reactjs.org.** Если это не так, то пулреквест следует открыть в родительском репозитории.

<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
