### PR TITLE
Update lists-and-keys.md

### DIFF
--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -185,8 +185,7 @@ function NumberList(props) {
   const numbers = props.numbers;
   const listItems = numbers.map((number) =>
     // Правильно! Ключ нужно определять внутри массива:
-    <ListItem key={number.toString()}
-              value={number} />
+    <ListItem key={number.toString()} value={number} />
   );
   return (
     <ul>


### PR DESCRIPTION
Возможно из-за того что 11 строка не подсвечена `value` не переносится и образовывается одна пустая строка, хотя в md файле все нормально отображается. Привел пример к виду оригинала.
https://ru.reactjs.org/docs/lists-and-keys.html#extracting-components-with-keys
![2020-06-09_21-42-57](https://user-images.githubusercontent.com/45208779/84187633-0217fa00-aa9b-11ea-8896-203069cd2b64.png)
![2020-06-09_21-48-18](https://user-images.githubusercontent.com/45208779/84187637-03e1bd80-aa9b-11ea-8910-ad3475a8fd99.png)
