### PR TITLE
fixed translation

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -419,12 +419,6 @@ this.setState(function(state, props) {
 Компонент может передать своё состояние вниз по дереву в виде пропсов дочерних компонентов:
 
 ```js
-<h2>Сейчас {this.state.date.toLocaleTimeString()}.</h2>
-```
-
-Своё состояние можно передать и другому пользовательскому компоненту:
-
-```js
 <FormattedDate date={this.state.date} />
 ```
 


### PR DESCRIPTION
> Компонент может передать своё состояние вниз по дереву в виде пропсов дочерних компонентов:
>
>`<h2>Сейчас {this.state.date.toLocaleTimeString()}.</h2>`

Некорректный пример кода. `<h2>...</h2>` является не компонентом, а элементом, у него нет пропсов и в них ничего не передаётся.

В оригинале этого куска кода нет, предлагаю и в переводе тоже опустить его.




**Если ваш пулреквест является исправлением бага, а не переводом, то сперва убедитесь, что проблема относится ТОЛЬКО к https://ru.reactjs.org, а не к https://reactjs.org.** Если это не так, то пулреквест следует открыть в родительском репозитории.

<!--
Прежде чем создавать пулреквест, пожалуйста, прочтите полностью правила перевода по ссылке ниже и поправьте свой перевод:

https://github.com/reactjs/ru.reactjs.org/blob/master/TRANSLATION.md

ВНИМАНИЕ: 90% переводов страдают от одной и той же проблемы: нагромождения существительных.
Пройдитесь по переводу и поправьте его *сейчас*, чтобы не тратить время на ревью.

Пример «до»: «Объявление переменной и использование её в `if`-выражении это вполне рабочий вариант условного рендеринга.»
Пример «после»: «Нет ничего плохого в том, чтобы объявить переменную и условно рендерить компонент `if`-выражением.»

Берегите глаголы!
-->
