### PR TITLE
Fix hooks-faq.md, unnecessary dependency in example?

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -968,7 +968,7 @@ function useEventCallback(fn, dependencies) {
 
   useEffect(() => {
     ref.current = fn;
-  }, [fn, ...dependencies]);
+  }, dependencies);
 
   return useCallback(() => {
     const fn = ref.current;


### PR DESCRIPTION
If I understand correctly the intended API of the `useEventCallback` custom hook, the `dependencies` array should contain all the dependencies of the `fn` callback itself (as in the standard `useCallback` hook).

Thus, there is no need to additionally specify the `fn` callback itself in the dependencies of this effect -- you need to update the link to `fn` in the ref only when something from the `dependencies` array changes.

Moreover, now, due to the fact that `fn` is specified in the effect dependencies, this effect is called after every render of the `Form` -- since `fn`, as an arrow function literal, is created on every render.