### PR TITLE
Improve translation for PropTypes (requiring-single-child)

### DIFF
--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -134,17 +134,16 @@ MyComponent.propTypes = {
 };
 ```
 
-### Ограничение на один дочерний компонент {#requiring-single-child}
+### Требование одного дочернего элемента {#requiring-single-child}
 
-С помощью `PropTypes.element` вы можете указать, что в качестве дочернего может быть передан только один элемент.
+С помощью `PropTypes.element` вы можете указать, что только один дочерний элемент может быть передан компоненту в качестве потомка.
 
 ```javascript
 import PropTypes from 'prop-types';
 
 class MyComponent extends React.Component {
   render() {
-    // Это должен быть ровно один элемент.
-    // Иначе вы увидите предупреждение
+    // Это должен быть ровно один элемент, иначе вы увидите предупреждение.
     const children = this.props.children;
     return (
       <div>


### PR DESCRIPTION
Привет,
Я заметил в документации некоторые несоответствия перевода для [PropTypes](https://reactjs.org/docs/typechecking-with-proptypes.html), которые были устранены данным PR.

**Текущий вариант перевода**: "_Ограничение на один дочерний компонент
С помощью `PropTypes.element` вы можете указать, что в качестве дочернего может быть передан только один элемент._", изменен в соответствии с оригинальным текстом ( см. screenshot ).
![Screenshot_2](https://user-images.githubusercontent.com/46906648/141657036-e44cc3ac-248b-4079-99fc-4163d2b768f2.jpg)


**Обновленный перевод**: "_Требование одного дочернего элемента
С помощью `PropTypes.element` вы можете указать, что только один дочерний элемент может быть передан компоненту в качестве потомка._"



