### PR TITLE
Update info about hooks and react-dom

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -108,13 +108,13 @@ const [state, setState] = useState(() => {
 
 Обратите внимание, что для React всё ещё может быть необходим повторный рендер этого компонента. Это не должно быть проблемой, потому что React не будет сильно «углубляться» в дерево. Если вы делаете дорогостоящие вычисления во время рендеринга, вы можете оптимизировать их с помощью `useMemo`.
 
-#### Batching of state updates {#batching-of-state-updates}
+#### Группировка обновлений состояния {#batching-of-state-updates}
 
-React may group several state updates into a single re-render to improve performance. Normally, this improves performance and shouldn't affect your application's behavior.
+React может группировать несколько обновлений состояния в один повторный рендер для улучшения производительности. Обычно это улучшает производительность и не должно влиять на поведение вашего приложения.
 
-Before React 18, only updates inside React event handlers were batched. Starting with React 18, [batching is enabled for all updates by default](/blog/2022/03/08/react-18-upgrade-guide.html#automatic-batching). Note that React makes sure that updates from several *different* user-initiated events -- for example, clicking a button twice -- are always processed separately and do not get batched. This prevents logical mistakes.
+До 18 версии React группировал только обновления внутри обработчиков событий. Начиная с 18 версии, [группировка включена по умолчанию для всех обновлений](/blog/2022/03/08/react-18-upgrade-guide.html#automatic-batching). Обратите внимание, что если обновления вызваны несколькими *различными* действиями пользователя -- например, пользователь дважды кликнул на кнопку -- то они обрабатываются раздельно и не будут сгруппированы. Это позволяет избежать логических ошибок.
 
-In the rare case that you need to force the DOM update to be applied synchronously, you may wrap it in [`flushSync`](/docs/react-dom.html#flushsync). However, this can hurt performance so do this only where needed.
+В редких случаях, когда вам нужно вызвать принудительное синхронное обновление DOM, вы можете обернуть его в [`flushSync`](/docs/react-dom.html#flushsync). Однако это может вызвать ухудшение производительности, используйте это только в тех случаях, где это действительно нужно.
 
 ### `useEffect` {#useeffect}
 
@@ -152,11 +152,11 @@ useEffect(() => {
 
 Однако не все эффекты могут быть отложены. Например, изменение DOM, которое видно пользователю, должно запускаться синхронно до следующей отрисовки, чтобы пользователь не замечал визуального несоответствия. (Различие концептуально схоже с пассивным и активным слушателями событий.) Для этих типов эффектов React предоставляет один дополнительный хук, называемый [`useLayoutEffect`](#uselayouteffect). Он имеет ту же сигнатуру, что и `useEffect`, и отличается только в его запуске.
 
-Additionally, starting in React 18, the function passed to `useEffect` will fire synchronously **before** layout and paint when it's the result of a discrete user input such as a click, or when it's the result of an update wrapped in [`flushSync`](/docs/react-dom.html#flushsync). This behavior allows the result of the effect to be observed by the event system, or by the caller of [`flushSync`](/docs/react-dom.html#flushsync).
+Также с 18 версии React, функция, переданная в `useEffect`, будет вызвана синхронно **перед** разметкой и отрисовкой, если эффект был вызван действием пользователя или результат обновления был обернут в [`flushSync`](/docs/react-dom.html#flushsync). Такое поведение позволяет системе событий или функции, вызвавшей [`flushSync`](/docs/react-dom.html#flushsync) следить за результатом эффекта.
 
 > Примечание
-> 
-> This only affects the timing of when the function passed to `useEffect` is called - updates scheduled inside these effects are still deferred. This is different than [`useLayoutEffect`](#uselayouteffect), which fires the function and processes the updates inside of it immediately.
+>
+> Это влияет только на время, когда функция, переданная в `useEffect`, будет вызвана - обновления, которые запланированы внутри эффектов останутся отложенными. Это поведение отлично от [`useLayoutEffect`](#uselayouteffect), который вызывает функцию и обрабатывает обновления внутри него мнгновенно.
 
 Хотя `useEffect` откладывается до тех пор, пока браузер не выполнит отрисовку, он гарантированно срабатывает перед любыми новыми рендерами. React всегда полностью применяет эффекты предыдущего рендера перед началом нового обновления.
 

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -12,31 +12,31 @@ permalink: docs/react-dom.html
 import * as ReactDOM from 'react-dom';
 ```
 
-If you use ES5 with npm, you can write:
+Если вы используете ES5 с npm, можете написать:
 
 ```js
 var ReactDOM = require('react-dom');
 ```
 
-The `react-dom` package also provides modules specific to client and server apps:
-- [`react-dom/client`](/docs/react-dom-client.html)
+Также `react-dom` предоставляет отдельные модули для клиентских и серверных приложений:
+- [`react-dom/client`](https://reactjs.org/docs/react-dom-client.html)
 - [`react-dom/server`](/docs/react-dom-server.html)
 
 ## Обзор {#overview}
 
-The `react-dom` package exports these methods:
+Пакет `react-dom` экспортирует следующие методы:
 - [`createPortal()`](#createportal)
 - [`flushSync()`](#flushsync)
 
-These `react-dom` methods are also exported, but are considered legacy:
+Следующие методы `react-dom` все еще экспортируются, но считаются устаревшими:
 - [`render()`](#render)
 - [`hydrate()`](#hydrate)
 - [`findDOMNode()`](#finddomnode)
 - [`unmountComponentAtNode()`](#unmountcomponentatnode)
 
-> Примечание: 
-> 
-> Both `render` and `hydrate` have been replaced with new [client methods](/docs/react-dom-client.html) in React 18. These methods will warn that your app will behave as if it's running React 17 (learn more [here](https://reactjs.org/link/switch-to-createroot)).
+> Примечание:
+>
+> Методы `render` и `hydrate` были заменены на новые [client методы](https://reactjs.org/docs/react-dom-client.html) в React 18. Эти методы будут предупреждать, что ваше приложение будет работать, словно используется версия React 17  (узнайте больше [здесь](https://reactjs.org/link/switch-to-createroot)).
 
 ### Поддержка браузерами {#browser-support}
 
@@ -54,7 +54,7 @@ React поддерживает все современные браузеры, �
 createPortal(child, container)
 ```
 
-Creates a portal. Portals provide a way to [render children into a DOM node that exists outside the hierarchy of the DOM component](/docs/portals.html).
+Создаёт портал. Порталы предоставляют способ [отрендерить дочерние элементы в узле DOM, который существует вне иерархии DOM-компонента](/docs/portals.html).
 
 ### `flushSync()` {#flushsync}
 
@@ -62,27 +62,27 @@ Creates a portal. Portals provide a way to [render children into a DOM node that
 flushSync(callback)
 ```
 
-Force React to flush any updates inside the provided callback synchronously. This ensures that the DOM is updated immediately.
+Заставляет React произвести любые обновления внутри колбэка синхронно. При этом DOM обновляется сразу.
 
 ```javascript
-// Force this state update to be synchronous.
+// Принудительно укажем, что данное обновление состояния должно быть синхронным.
 flushSync(() => {
   setCount(count + 1);
 });
-// By this point, DOM is updated.
+// К этому моменту DOM уже обновлен.
 ```
 
 > Примечание:
-> 
-> `flushSync` can significantly hurt performance. Use sparingly.
-> 
-> `flushSync` may force pending Suspense boundaries to show their `fallback` state.
-> 
-> `flushSync` may also run pending effects and synchronously apply any updates they contain before returning.
-> 
-> `flushSync` may also flush updates outside the callback when necessary to flush the updates inside the callback. For example, if there are pending updates from a click, React may flush those before flushing the updates inside the callback.
+>
+> `flushSync` может сильно влиять на производительность. Используйте в редких случаях.
+>
+> `flushSync` может заставить Suspense, которые ожидают содержимое, показывать их `fallback` состояние.
+>
+> `flushSync` может вызывать ожидающие эффекты и синхронно применять любые их обновления перед возвратом.
+>
+> `flushSync` может вызывать обновления вне колбэка, если это нужно для выполнения обновлений внутри колбэка. Например, если есть ожидающие обновления от клика, React может применить их до того, как применит обновления внутри колбэка.
 
-## Legacy Reference {#legacy-reference}
+## Устаревшие методы {#legacy-reference}
 ### `render()` {#render}
 ```javascript
 render(element, container[, callback])
@@ -90,7 +90,7 @@ render(element, container[, callback])
 
 > Примечание:
 >
-> `render` has been replaced with `createRoot` in React 18. See [createRoot](/docs/react-dom-client.html#createroot) for more info.
+> `render` был заменен на `createRoot` в React 18. Подробнее о [createRoot](https://reactjs.org/docs/react-dom-client.html#createroot).
 
 Рендерит React-элемент в DOM-элемент, переданный в аргумент `container` и возвращает [ссылку](/docs/more-about-refs.html) на компонент (или возвращает `null` для [компонентов без состояния](/docs/components-and-props.html#function-and-class-components)).
 


### PR DESCRIPTION
Добрый день,
- изменила версию в ссылках на cdn с 17 на 18ю
- привела страницу ReactDOM в аналогичное состояние с [EN-версией](https://reactjs.org/docs/react-dom.html)
- добавила информацию на страницу справочника хуков про обновления в 18й версии
![Capture2](https://user-images.githubusercontent.com/26360334/174346064-af8dc875-1c57-4127-9c60-10f9739d745f.PNG)
![Capture44](https://user-images.githubusercontent.com/26360334/174346070-0d096602-e7cf-4858-8d1d-6c8a46964310.PNG)
![Capture](https://user-images.githubusercontent.com/26360334/174346073-818e6c84-803b-43c8-9747-87bc77619640.PNG)

